### PR TITLE
null terminate string after strncpy

### DIFF
--- a/lib/porg-log/log.c
+++ b/lib/porg-log/log.c
@@ -102,12 +102,14 @@ static void porg_get_absolute_path(int fd, const char* path, char* abs_path)
 	/* relative to CWD */
 	else if (fd < 0) {
 		strncpy(abs_path, cwd, PORG_BUFSIZE - 1);
+		abs_path[PORG_BUFSIZE - 1] = 0;
 		strncat(abs_path, "/", PORG_BUFSIZE - strlen(abs_path) - 1);
 		strncat(abs_path, path, PORG_BUFSIZE - strlen(abs_path) - 1);
 	}
 	/* relative to directory fd */
 	else if (fchdir(fd) == 0 && getcwd(aux, PORG_BUFSIZE) && chdir(cwd) == 0) {
 		strncpy(abs_path, aux, PORG_BUFSIZE - 1);
+		abs_path[PORG_BUFSIZE - 1] = 0;
 		strncat(abs_path, "/", PORG_BUFSIZE - strlen(abs_path) - 1);
 		strncat(abs_path, path, PORG_BUFSIZE - strlen(abs_path) - 1);
 	}


### PR DESCRIPTION
to prevent possible buffer overflows
~~~
In file included from /usr/include/string.h:495,
                   from ../../config-bot.h:35,
                   from ../../config.h:167,
                   from log.c:9:
  In function ‘strncpy’,
      inlined from ‘porg_get_absolute_path’ at log.c:110:3:
  /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ output may be truncated copying 4095 bytes from a string of length 4095 [-Werror=stringop-truncation]
    106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  In function ‘strncpy’,
      inlined from ‘porg_get_absolute_path’ at log.c:104:3:
  /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ output may be truncated copying 4095 bytes from a string of length 4095 [-Werror=stringop-truncation]
    106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  cc1: all warnings being treated as errors
~~~