### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: C/C++ CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/drfiemost/porg/security/code-scanning/1](https://github.com/drfiemost/porg/security/code-scanning/1)

In general, the problem is fixed by explicitly declaring a `permissions` block either at the workflow root (applies to all jobs) or on the specific job. For this workflow, the job only needs to read repository contents to perform a checkout; no write permissions are required.

The best minimal fix without changing functionality is to add a root-level `permissions` block just under the `name:` field setting `contents: read`. This will apply to the `build` job (and any future jobs) unless a job-specific override is added later. No other steps in the workflow need modification, and no additional imports or tooling changes are required. Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: C/C++ CI` line and the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
